### PR TITLE
Release 0.4.2 (+ guard against merging a -dev version)

### DIFF
--- a/.github/workflows/test.pkl
+++ b/.github/workflows/test.pkl
@@ -25,6 +25,20 @@ jobs {
       new {
         uses = "actions/checkout@v7"
       }
+      // Guard: main must hold a live (non -dev) version. Merging to main cuts a
+      // release, so fail the check when mix.exs still has a -dev version — that
+      // blocks the merge until it's bumped. Make this a required status check
+      // in branch protection.
+      new {
+        name = "Reject -dev version"
+        run = """
+          v=$(grep -oE 'version: "[^"]+"' mix.exs | head -1 | cut -d'"' -f2)
+          echo "mix.exs version: $v"
+          case "$v" in
+            *-dev) echo "::error::mix.exs version is $v — bump to the live (non -dev) version before merging"; exit 1 ;;
+          esac
+          """
+      }
       // install: false — mise-action auto-adds --locked when mise.lock exists,
       // and the lock lacks linux-x64 (glibc) URLs for erlang and conda:xz-tools,
       // so a strict install aborts. cache: false because mise-action saves no

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,13 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+    - name: Reject -dev version
+      run: |-
+        v=$(grep -oE 'version: "[^"]+"' mix.exs | head -1 | cut -d'"' -f2)
+        echo "mix.exs version: $v"
+        case "$v" in
+          *-dev) echo "::error::mix.exs version is $v — bump to the live (non -dev) version before merging"; exit 1 ;;
+        esac
     - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
       with:
         version: 2026.8.5

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule AwsSsoConfigGenerator.MixProject do
   def project do
     [
       app: :aws_sso_config_generator,
-      version: "0.4.2-dev",
+      version: "0.4.2",
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/release-notes/0.4.2.md
+++ b/release-notes/0.4.2.md
@@ -3,15 +3,25 @@
 ## 🚀 What's New
 
 - Fixed pagination in AWS SSO List Account Roles: accounts with more than one page of roles now return **all** of their roles instead of just the first page.
+- More robust listing: both account and role lookups now fail with a clear message on an AWS API error instead of crashing, and correctly stop at the last page when AWS omits the pagination token.
 - Removed the unused `aws_credentials` dependency, which eliminates the repeated `Provider :aws_credentials_* reports {:error, ...}` log spam at startup. This tool authenticates with AWS SSO bearer tokens and never needed IAM credentials.
-- Added an [aqua](https://aquaproj.github.io/) registry (`registry.yaml`) so you can install and manage the tool with [mise](https://mise.jdx.dev/) or aqua instead of downloading binaries by hand. See the README's "Install with mise or aqua" section.
+- Added an [aqua](https://aquaproj.github.io/) registry (`registry.yaml`) so you can install and manage the tool with [mise](https://mise.jdx.dev/) instead of downloading binaries by hand — see **Install with mise** below.
+
+## 📦 Install with mise
+
+Until this package lands in the official aqua-registry, install it straight from this repo's `registry.yaml` with [mise](https://mise.jdx.dev/) (via its aqua backend). mise picks the right binary for your OS/arch and verifies it against `aws-sso-config-generator-checksums.txt`.
+
+```sh
+MISE_AQUA_REGISTRIES=https://github.com/djgoku/aws-sso-config-generator \
+  mise use -g "aqua:djgoku/aws-sso-config-generator@0.4.2"
+```
 
 ## 🔧 Under the Hood
 
 - Completed the migration to [mise](https://mise.jdx.dev/) for toolchain management (devbox removed) and bumped to Elixir 1.20 / Erlang 29 / Zig 0.16.
-- Burrito releases now build with the mise-installed OTP as the runtime, avoiding a separate ERTS download.
-- CI moved to GitHub Actions with workflows generated from [Pkl](https://pkl-lang.org/), with each action pinned to a git SHA (kept current by Dependabot).
-- Dependency and security updates: `aws`, `hackney` (clears several advisories), and `bandit`.
+- Burrito releases build with the mise-installed OTP as the runtime where possible (Apple Silicon), avoiding a separate ERTS download.
+- Dependency and security updates: `aws`, `hackney` (clears several advisories), and `bandit`; `mix hex.audit` is clean.
+- CI moved to GitHub Actions with workflows generated from [Pkl](https://pkl-lang.org/) — each action pinned to a git SHA (kept current by Dependabot) and on Node 24. Linux builds run on arm64 runners, Windows builds in parallel, and the toolchain + Burrito ERTS downloads are cached between runs.
 
 ## ⚠️ Deprecation
 


### PR DESCRIPTION
Cuts the **0.4.2** release and adds a guard so we don't ship a `-dev` version again.

## Changes
- **Bump `0.4.2-dev` → `0.4.2`** so merging this to `main` publishes a real release (not a prerelease).
- **Changelog:** fleshed out `release-notes/0.4.2.md` (robust list-accounts/roles error handling, arm64 CI + caching, Node 24 action bumps) and added an **Install with mise** section with a copy-paste command.
- **Guard:** the `test` workflow now fails fast (`Reject -dev version`) when `mix.exs` still ends in `-dev`. Since merging to `main` cuts a release, this blocks a `-dev` from being released by accident.

## After merge
- Make **`Reject -dev version` / the `test` check a *required* status check** on `main` so the guard actually blocks merges (a red X alone doesn't).
- Merging this triggers `main.yml`, which sees the non-`-dev` version and publishes `0.4.2` from `release-notes/0.4.2.md`.
- Going forward, keep `main` at the live version; cut `-dev` prereleases from the `-dev` tag (parking `main` at `X.Y.Z-dev` would fail the guard).